### PR TITLE
Add Ability to make get requests using query and find

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,24 @@ To access the object in the RestforceMock object
   RestforceMock::Sandbox.get_object("Contact", "HGUKK674J79HjsH")
 ```
 
+To find an object with the salesforce find method
+
+```ruby
+  client = RestforceMock::Client.new
+  RestforceMock::Sandbox.add_object("Contact", '12345', {:Email=>"example@yahoo.com"})
+  client.find('Contact', '12345')
+```
+
+To make a query with the salesforce query method
+
+```ruby
+  client = RestforceMock::Client.new
+  RestforceMock::Sandbox.add_object("Contact", '12345', {:Email=>"example@yahoo.com"})
+  client.query("Select Id FROM Contact WHERE Email = 'example@yahoo.com'")
+```
+
+Note: when making a `find` or `query`, it should be in the format specified above.
+
 RestforceMock sandbox is **shared across all your tests** (same way as real Salesforce instace would be), hence,
 after completion of tests make sure to clean up if necessary
 

--- a/lib/restforce_mock/client.rb
+++ b/lib/restforce_mock/client.rb
@@ -7,6 +7,25 @@ module RestforceMock
     include ::Restforce::Concerns::API
     include RestforceMock::Sandbox
 
+    def mashify?
+      true
+    end
+
+    def api_get(url, attrs = nil)
+      url=~/sobjects\/(.+)\/(.+)/
+      object=$1
+      id=$2
+
+      if !attrs.nil? && url == 'query'
+        query = attrs.values.first
+        response = get_object_from_query(query)
+        return Body.new(response, url)
+      else
+        response = get_object(object, id)
+        return Body.new(response)
+      end
+    end
+
     def api_patch(url, attrs)
       url=~/sobjects\/(.+)\/(.+)/
       object=$1
@@ -73,8 +92,17 @@ module RestforceMock
     end
 
     class Body
-      def initialize(id)
-        @body = {'id' => id}
+      def initialize(id, type= nil)
+        collection = {"totalSize"=>1, "done"=>true,
+                      "records"=>[{"attributes"=>{"type"=>"Contact", "url"=>""}, "Id"=> id}]}
+
+        @body =
+
+          if type == 'query'
+           Restforce::Collection.new(collection, Restforce::Data::Client.new)
+          else
+            {'id' => id}
+          end
       end
 
       def body

--- a/lib/restforce_mock/sandbox.rb
+++ b/lib/restforce_mock/sandbox.rb
@@ -12,8 +12,33 @@ module RestforceMock
       RestforceMock::Sandbox.add_object(name, id, values)
     end
 
+    def get_object(name, id)
+      RestforceMock::Sandbox.get_object(name, id)
+    end
+
     def self.get_object(name, id)
       storage[name][id]
+    end
+
+    def get_object_from_query(query)
+      RestforceMock::Sandbox.find_object(query)
+    end
+
+    def self.find_object(query)
+      # This will only support making queries in this format:
+      # client.query("Select Id FROM Contact WHERE Email = 'debrah.obrian@yahoo.com'")
+
+      split_query = query.split
+
+      storage_name = split_query[3]
+      key = "#{split_query[5]}".to_sym
+      val = split_query.last
+                  .gsub(/^'|'$/, '')
+                  .gsub('\\', '')
+
+      if storage[storage_name].has_value?( key => val)
+        return storage[storage_name].keys.first
+      end
     end
 
     def self.update_object(name, id, attrs)

--- a/lib/restforce_mock/version.rb
+++ b/lib/restforce_mock/version.rb
@@ -1,3 +1,3 @@
 module RestforceMock
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end

--- a/spec/restforce_mock_spec.rb
+++ b/spec/restforce_mock_spec.rb
@@ -172,6 +172,59 @@ describe RestforceMock do
         end
       end
 
+      context 'api_get' do
+        describe '#find' do
+          it "mocks out GET request for a find" do
+            RestforceMock::Sandbox.add_object("Contact", '12345',
+                                              {:Email=>"debrah.obrian@yahoo.com"})
+            response = client.api_get("/sobjects/Contact/12345", '12345')
+            expect(response.body).to eq({"id"=>{:Email=>"debrah.obrian@yahoo.com"}})
+          end
+
+          it "returns nil if object does not exist" do
+            response = client.api_get("/sobjects/Contact/12345", '123457')
+            expect(response.body).to eq ({"id" => nil})
+          end
+        end
+
+        describe 'mocks out GET request for a query' do
+          it "given email without single quote" do
+            RestforceMock::Sandbox.add_object("Contact", '12345',
+                                              {:Email=>"debrah.obrian@yahoo.com"})
+            email = "debrah.obrian@yahoo.com"
+            response = client.api_get("query", q: "Select Id FROM Contact WHERE Email = '#{email}'")
+            expect(response.body.map(&:Id).first).to eq('12345')
+          end
+
+          it "given email with escaped single quotes" do
+            RestforceMock::Sandbox.add_object("Contact", '123456',
+                                              {:Email=>"debrah.o'brian@yahoo.com"})
+            email = "debrah.o\\'brian@yahoo.com"
+            response = client.api_get("query", q: "Select Id FROM Contact WHERE Email = '#{email}'")
+            expect(response.body.map(&:Id).first).to eq('123456')
+          end
+
+          it "returns nil if object does not exist" do
+            email = "no.exist@yahoo.com"
+            response = client.api_get("query", q: "Select Id FROM Contact WHERE Email = '#{email}'")
+            expect(response.body.map(&:Id).first).to eq nil
+          end
+        end
+
+        describe '#get_object' do
+          it "mocks out GET request using the sandbox get object" do
+            RestforceMock::Sandbox.add_object("Contact", '12345',
+                                              {:Email=>"debrah.obrian@yahoo.com"})
+            response = RestforceMock::Sandbox.get_object("Contact", '12345')
+            expect(response).to eq({:Email=>"debrah.obrian@yahoo.com"})
+          end
+
+          it "returns nil if object does not exist" do
+            response = RestforceMock::Sandbox.get_object("Contact", '1234598')
+            expect(response).to eq nil
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
The api_get method was not mocked in the client.rb file.
This was causing any get requests to fail.

We should be able to make queries now with the formats:
  `client.find('Contact', id)`

  `email =  "debrah.obrian@yahoo.com" || "debrah.o'brian@yahoo.com" |`
  `client.query("Select Id FROM Contact WHERE Email = '#{email}'")`

This fix only supports doing queries in the formats specified above.