### PR TITLE
Avoid using deprecated error classes

### DIFF
--- a/lib/restforce_mock/client.rb
+++ b/lib/restforce_mock/client.rb
@@ -61,7 +61,7 @@ module RestforceMock
 
       missing = required - attrs.keys - RestforceMock.configuration.required_exclusions
       if missing.length > 0
-        raise Faraday::Error::ResourceNotFound.new(
+        raise Faraday::ResourceNotFound.new(
           "REQUIRED_FIELD_MISSING: Required fields are missing: #{missing}")
       end
     end
@@ -69,7 +69,7 @@ module RestforceMock
     def validate_presence!(object, id)
       unless RestforceMock::Sandbox.storage[object][id]
         msg = "Provided external ID field does not exist or is not accessible: #{id}"
-        raise Faraday::Error::ResourceNotFound.new(msg)
+        raise Faraday::ResourceNotFound.new(msg)
       end
     end
 

--- a/lib/restforce_mock/sandbox.rb
+++ b/lib/restforce_mock/sandbox.rb
@@ -80,7 +80,7 @@ module RestforceMock
     def self.validate_all_present_fields!(current, attrs)
       missing = attrs.keys - current.keys
       unless missing.length == 0
-        raise Faraday::Error::ResourceNotFound.new(
+        raise Faraday::ResourceNotFound.new(
           "INVALID_FIELD_FOR_INSERT_UPDATE: Unable to create/update fields: #{missing}." +
           " Please check the security settings of this field and verify that it is " +
           "read/write for your profile or permission set")

--- a/restforce_mock.gemspec
+++ b/restforce_mock.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "restforce"
-  spec.add_development_dependency "bundler", "~> 2.2.33"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
As of Faraday v0.17.6 these error classes are deprecated:
https://github.com/lostisland/faraday/blob/v0.17.6/lib/faraday/error.rb#L151-L155

And as of Faraday v1.0.0 they are removed:
https://github.com/lostisland/faraday/blob/v1.0.0/lib/faraday/error.rb